### PR TITLE
feat(linux): add generic segmentation/receive offload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1", features = [
     "io-util",
 ], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
+etherparse = { version = "^0.14.0", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))'.dependencies]
 ioctl = { version = "0.8", package = "ioctl-sys" }
@@ -45,6 +46,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 [features]
 default = []
 async = ["tokio", "futures-core", "tokio-util"]
+offload = ["etherparse"]
 
 [[example]]
 name = "read-async"

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,21 @@ pub enum Error {
     #[error("out of range integral type conversion attempted")]
     TryFromIntError,
 
+    #[error("buffer too small")]
+    BufferTooSmall,
+
+    #[error("offload flow not found")]
+    OffloadFlowNotFound,
+
+    #[error("offload item invalid checksum")]
+    OffloadItemInvalidChecksum,
+
+    #[error("offload packet invalid checksum")]
+    OffloadPacketInvalidChecksum,
+
+    #[error("offload TCP PSH flag set")]
+    OffloadTcpPshFlagSet,
+
     #[error(transparent)]
     Io(#[from] std::io::Error),
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -17,6 +17,10 @@
 pub mod sys;
 
 mod device;
+
+#[cfg(feature = "offload")]
+mod offload;
+
 pub use self::device::Device;
 
 use crate::configuration::Configuration;

--- a/src/platform/linux/offload/coalesce.rs
+++ b/src/platform/linux/offload/coalesce.rs
@@ -57,7 +57,7 @@ impl IpCoaleasceable for Ipv4Header {
             return false;
         }
 
-        return true;
+       true
     }
 }
 
@@ -72,7 +72,7 @@ impl IpCoaleasceable for Ipv6Header {
             return false;
         }
 
-        return true;
+        true
     }
 }
 

--- a/src/platform/linux/offload/coalesce.rs
+++ b/src/platform/linux/offload/coalesce.rs
@@ -1,0 +1,205 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+use crate::platform::linux::offload::packet::{IpPacket, TcpPacket, UdpPacket};
+use crate::platform::linux::offload::tcp::TcpGroItem;
+use crate::platform::linux::offload::udp::UdpGroItem;
+use crate::{Error, Result};
+use bytes::BufMut;
+use etherparse::{IpHeaders, Ipv4Header, Ipv6Header};
+
+pub(crate) enum CoalesceResult {
+    InsufficientCapacity,
+    PSHEnding,
+    ItemInvalidChecksum,
+    PacketInvalidChecksum,
+    Success,
+}
+
+pub(crate) trait IpCoaleasceable {
+    fn can_coalesce(&self, other: &Self) -> bool;
+}
+
+pub(crate) trait TransportCoaleasceable {
+    type GroItem;
+
+    fn can_coalesce(&self, gro_item: &Self::GroItem) -> bool;
+    fn coalesce(&mut self, gro_item: &mut Self::GroItem) -> Result<()>;
+}
+
+impl IpCoaleasceable for Ipv4Header {
+    #[inline]
+    fn can_coalesce(&self, other: &Self) -> bool {
+        if self.dscp != other.dscp {
+            return false;
+        }
+
+        if self.ecn != other.ecn {
+            return false;
+        }
+
+        if self.dont_fragment != other.dont_fragment {
+            return false;
+        }
+
+        if self.time_to_live != other.time_to_live {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+impl IpCoaleasceable for Ipv6Header {
+    #[inline]
+    fn can_coalesce(&self, other: &Self) -> bool {
+        if self.traffic_class != other.traffic_class {
+            return false;
+        }
+
+        if self.hop_limit != other.hop_limit {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+impl IpCoaleasceable for IpHeaders {
+    #[inline]
+    fn can_coalesce(&self, other: &Self) -> bool {
+        match (self, other) {
+            (IpHeaders::Ipv4(self_ipv4_header, _), IpHeaders::Ipv4(other_ipv4_header, _)) => {
+                self_ipv4_header.can_coalesce(other_ipv4_header)
+            }
+            (IpHeaders::Ipv6(self_ipv6_header, _), IpHeaders::Ipv6(other_ipv6_header, _)) => {
+                self_ipv6_header.can_coalesce(other_ipv6_header)
+            }
+            _ => false,
+        }
+    }
+}
+
+impl TransportCoaleasceable for IpPacket<TcpPacket> {
+    type GroItem = TcpGroItem;
+
+    #[inline]
+    fn can_coalesce(&self, gro_item: &TcpGroItem) -> bool {
+        if !self.header.can_coalesce(&gro_item.ip_header) {
+            return false;
+        }
+
+        let tcp_header = &self.transport.header;
+        let data = &self.transport.data;
+
+        if tcp_header.header_len() != tcp_header.header_len() {
+            return false;
+        }
+
+        if tcp_header.options != tcp_header.options {
+            return false;
+        }
+
+        let mut len = gro_item.data.len() as u32;
+        len += gro_item.num_merged * gro_item.data.len() as u32;
+
+        if tcp_header.sequence_number == gro_item.seq_num + len {
+            if tcp_header.psh {
+                return false;
+            }
+
+            if data.len() > gro_item.data.len() {
+                return false;
+            }
+
+            return true;
+        } else if tcp_header.sequence_number + data.len() as u32 == gro_item.seq_num {
+            if tcp_header.psh {
+                return false;
+            }
+
+            if data.len() < gro_item.data.len() {
+                return false;
+            }
+
+            if data.len() > gro_item.data.len() && gro_item.num_merged > 0 {
+                return false;
+            }
+
+            return true;
+        }
+
+        false
+    }
+
+    #[inline]
+    fn coalesce(&mut self, gro_item: &mut TcpGroItem) -> Result<()> {
+        let tcp_header = &self.transport.header;
+        let data = &self.transport.data;
+
+        if gro_item.data.remaining_mut() < self.transport.data.len() {
+            return Err(Error::BufferTooSmall);
+        }
+
+        if tcp_header.psh {
+            return Err(Error::OffloadTcpPshFlagSet);
+        }
+
+        // TODO: checksums?
+
+        gro_item.seq_num = tcp_header.sequence_number;
+        gro_item.data.chunk_mut().copy_from_slice(data);
+
+        Ok(())
+    }
+}
+
+impl TransportCoaleasceable for IpPacket<UdpPacket> {
+    type GroItem = UdpGroItem;
+
+    #[inline]
+    fn can_coalesce(&self, gro_item: &UdpGroItem) -> bool {
+        if !self.header.can_coalesce(&gro_item.ip_header) {
+            return false;
+        }
+
+        let udp_header = &self.transport.header;
+
+        if udp_header.length > gro_item.udp_header.length {
+            return false;
+        }
+
+        true
+    }
+
+    #[inline]
+    fn coalesce(&mut self, gro_item: &mut UdpGroItem) -> Result<()> {
+        let data = &self.transport.data;
+
+        if gro_item.data.remaining_mut() < data.len() {
+            return Err(Error::BufferTooSmall);
+        }
+
+        if gro_item.num_merged == 0 && gro_item.checksum_known_invalid {
+            return Err(Error::OffloadItemInvalidChecksum);
+        }
+
+        // TODO: checksums?
+
+        gro_item.data.chunk_mut().copy_from_slice(data);
+        gro_item.num_merged += 1;
+
+        Ok(())
+    }
+}

--- a/src/platform/linux/offload/coalesce.rs
+++ b/src/platform/linux/offload/coalesce.rs
@@ -57,7 +57,7 @@ impl IpCoaleasceable for Ipv4Header {
             return false;
         }
 
-       true
+        true
     }
 }
 

--- a/src/platform/linux/offload/mod.rs
+++ b/src/platform/linux/offload/mod.rs
@@ -39,7 +39,7 @@ impl<K: Hash + Eq, T> GroTable<K, T> {
     /// Get or insert a new item into the table.
     pub(crate) fn get_or_insert(&mut self, key: K, item: T) -> &mut Vec<T> {
         match self.items_by_flow.entry(key) {
-            Entry::Occupied(mut entry) => entry.into_mut(),
+            Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
                 let mut items = Vec::with_capacity(IDEAL_BATCH_SIZE);
                 items.push(item);

--- a/src/platform/linux/offload/mod.rs
+++ b/src/platform/linux/offload/mod.rs
@@ -1,0 +1,77 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+use crate::Error;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+mod coalesce;
+mod packet;
+mod tcp;
+mod udp;
+mod virtio;
+
+const IDEAL_BATCH_SIZE: usize = 128;
+
+pub(crate) struct GroTable<K, T> {
+    items_by_flow: HashMap<K, Vec<T>>,
+}
+
+impl<K: Hash + Eq, T> GroTable<K, T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            items_by_flow: HashMap::with_capacity(IDEAL_BATCH_SIZE),
+        }
+    }
+
+    /// Get or insert a new item into the table.
+    pub(crate) fn get_or_insert(&mut self, key: K, item: T) -> &mut Vec<T> {
+        match self.items_by_flow.entry(key) {
+            Entry::Occupied(mut entry) => entry.get_mut(),
+            Entry::Vacant(entry) => {
+                let mut items = Vec::with_capacity(IDEAL_BATCH_SIZE);
+                items.push(item);
+                entry.insert(items)
+            }
+        }
+    }
+
+    /// Updates the item for the given flow at the given index.
+    pub(crate) fn update_at(&mut self, key: K, index: usize, item: T) -> crate::Result<()> {
+        *self
+            .items_by_flow
+            .get_mut(&key)
+            .ok_or(Error::OffloadFlowNotFound)?
+            .get_mut(index)
+            .ok_or(Error::OffloadFlowNotFound)? = item;
+
+        Ok(())
+    }
+
+    /// Deletes the item for the given flow at the given index.
+    pub(crate) fn delete_at(&mut self, key: K, index: usize) -> crate::Result<()> {
+        self.items_by_flow
+            .get_mut(&key)
+            .map(|items| items.remove(index))
+            .ok_or(Error::OffloadFlowNotFound)?;
+
+        Ok(())
+    }
+
+    /// Clears the table.
+    pub(crate) fn clear(&mut self) {
+        self.items_by_flow.clear();
+    }
+}

--- a/src/platform/linux/offload/mod.rs
+++ b/src/platform/linux/offload/mod.rs
@@ -39,7 +39,7 @@ impl<K: Hash + Eq, T> GroTable<K, T> {
     /// Get or insert a new item into the table.
     pub(crate) fn get_or_insert(&mut self, key: K, item: T) -> &mut Vec<T> {
         match self.items_by_flow.entry(key) {
-            Entry::Occupied(mut entry) => entry.get_mut(),
+            Entry::Occupied(mut entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
                 let mut items = Vec::with_capacity(IDEAL_BATCH_SIZE);
                 items.push(item);

--- a/src/platform/linux/offload/packet.rs
+++ b/src/platform/linux/offload/packet.rs
@@ -1,0 +1,35 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+use bytes::Bytes;
+use etherparse::{IpHeaders, TcpHeader, UdpHeader};
+use std::fmt::Debug;
+
+#[derive(Clone, Debug)]
+pub(crate) struct IpPacket<T: Clone + Debug> {
+    pub(crate) header: IpHeaders,
+    pub(crate) transport: T,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TcpPacket {
+    pub(crate) header: TcpHeader,
+    pub(crate) data: Bytes,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct UdpPacket {
+    pub(crate) header: UdpHeader,
+    pub(crate) data: Bytes,
+}

--- a/src/platform/linux/offload/tcp.rs
+++ b/src/platform/linux/offload/tcp.rs
@@ -1,0 +1,38 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+use crate::platform::linux::offload::GroTable;
+use bytes::BytesMut;
+use etherparse::{IpHeaders, TcpHeader};
+use std::net::IpAddr;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct TcpFlowKey {
+    pub(crate) src_addr: IpAddr,
+    pub(crate) dst_addr: IpAddr,
+    pub(crate) src_port: u16,
+    pub(crate) dst_port: u16,
+    pub(crate) recv_ack: u32,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TcpGroItem {
+    pub(crate) seq_num: u32,
+    pub(crate) num_merged: u32,
+    pub(crate) ip_header: IpHeaders,
+    pub(crate) tcp_header: TcpHeader,
+    pub(crate) data: BytesMut,
+}
+
+pub(crate) type TcpGroTable = GroTable<TcpFlowKey, TcpGroItem>;

--- a/src/platform/linux/offload/udp.rs
+++ b/src/platform/linux/offload/udp.rs
@@ -1,0 +1,38 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+use crate::platform::linux::offload::GroTable;
+use bytes::BytesMut;
+use etherparse::{IpHeaders, UdpHeader};
+use std::net::IpAddr;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct UdpFlowKey {
+    pub(crate) src_addr: IpAddr,
+    pub(crate) dst_addr: IpAddr,
+    pub(crate) src_port: u16,
+    pub(crate) dst_port: u16,
+    pub(crate) recv_ack: u32,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct UdpGroItem {
+    pub(crate) num_merged: u32,
+    pub(crate) ip_header: IpHeaders,
+    pub(crate) udp_header: UdpHeader,
+    pub(crate) checksum_known_invalid: bool,
+    pub(crate) data: BytesMut,
+}
+
+pub(crate) type UdpGroTable = GroTable<UdpFlowKey, UdpGroItem>;

--- a/src/platform/linux/offload/virtio.rs
+++ b/src/platform/linux/offload/virtio.rs
@@ -1,0 +1,63 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+use crate::{Error, Result};
+use std::{mem, ptr};
+
+const TCP_FLAG_FIN: u8 = 0x01;
+const TCP_FLAG_PSH: u8 = 0x08;
+const TCP_FLAG_ACK: u8 = 0x10;
+
+const VIRTIO_NET_HEADER_SIZE: usize = mem::size_of::<VirtioNetHeader>();
+
+#[repr(C)]
+struct VirtioNetHeader {
+    flags: u8,
+    gso_type: u8,
+    header_len: u16,
+    gso_size: u16,
+    checksum_start: u16,
+    checksum_offset: u16,
+}
+
+impl VirtioNetHeader {
+    pub fn decode(data: &[u8]) -> Result<Self> {
+        if data.len() < VIRTIO_NET_HEADER_SIZE {
+            return Err(Error::BufferTooSmall);
+        }
+
+        unsafe {
+            // SAFETY:
+            // - data is valid to read
+            // - data is aligned
+            // - the bytes represent a valid header
+            ptr::read(data[..VIRTIO_NET_HEADER_SIZE].as_ptr() as *const _)
+        }
+    }
+
+    pub fn encode(&self, data: &mut [u8]) -> Result<()> {
+        if data.len() < VIRTIO_NET_HEADER_SIZE {
+            return Err(Error::BufferTooSmall);
+        }
+
+        unsafe {
+            // SAFETY:
+            // - data is valid to write
+            // - data is aligned
+            ptr::write(data[..VIRTIO_NET_HEADER_SIZE].as_mut_ptr() as *mut _, self);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds GSO/GRO capability on Linux to greatly increase overall throughput.

More information about GSO/GRO: https://docs.kernel.org/networking/segmentation-offloads.html
Motivation behind implementing these offloads: https://tailscale.com/blog/throughput-improvements

Using https://github.com/WireGuard/wireguard-go/blob/master/tun/offload_linux.go as a reference for implementation.