### PR TITLE
Fix: channel closed loop

### DIFF
--- a/src/async/win_device.rs
+++ b/src/async/win_device.rs
@@ -105,6 +105,7 @@ impl WinSession {
                 Ok(packet) => {
                     if let Err(err) = receiver_tx.send(packet.bytes().to_vec()) {
                         log::error!("{}", err);
+                        break;
                     }
                 }
                 Err(err) => {


### PR DESCRIPTION
When `WinSession` is dropped `Arc<wintun::Session>` stays inside the thread so `receive_blocking` is never finished, but channel is closed. Maybe also need `impl Drop for WinSession` with `self.session.shutdown()`?