### PR TITLE
Configure whether fd should be closed on drop

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -56,8 +56,8 @@ pub struct Configuration {
     pub(crate) raw_fd: Option<i32>,
     #[cfg(windows)]
     pub(crate) raw_handle: Option<WinHandle>,
-    #[cfg(not(windows))]
-    pub(crate) close_on_drop: Option<bool>,
+    #[cfg(unix)]
+    pub(crate) close_fd_on_drop: Option<bool>,
 }
 
 impl Configuration {
@@ -170,9 +170,9 @@ impl Configuration {
     /// The default behaviour is to close the received or tun2 generated file descriptor.
     /// Note: If this is set to false, it is up to the caller to ensure the
     /// file descriptor that they pass via [Configuration::raw_fd] is properly closed.
-    #[cfg(not(windows))]
-    pub fn close_on_drop(&mut self, value: bool) -> &mut Self {
-        self.close_on_drop = Some(value);
+    #[cfg(unix)]
+    pub fn close_fd_on_drop(&mut self, value: bool) -> &mut Self {
+        self.close_fd_on_drop = Some(value);
         self
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -56,6 +56,8 @@ pub struct Configuration {
     pub(crate) raw_fd: Option<i32>,
     #[cfg(windows)]
     pub(crate) raw_handle: Option<WinHandle>,
+    #[cfg(not(windows))]
+    pub(crate) close_on_drop: Option<bool>,
 }
 
 impl Configuration {
@@ -161,6 +163,16 @@ impl Configuration {
     #[cfg(windows)]
     pub fn raw_handle(&mut self, handle: std::os::windows::raw::HANDLE) -> &mut Self {
         self.raw_handle = Some(WinHandle(handle));
+        self
+    }
+
+    /// Set whether to close the received raw file descriptor on drop or not.
+    /// The default behaviour is to close the received or tun2 generated file descriptor.
+    /// Note: If this is set to false, it is up to the caller to ensure the
+    /// file descriptor that they pass via [Configuration::raw_fd] is properly closed.
+    #[cfg(not(windows))]
+    pub fn close_on_drop(&mut self, value: bool) -> &mut Self {
+        self.close_on_drop = Some(value);
         self
     }
 }

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -42,13 +42,14 @@ impl AsMut<dyn AbstractDevice + 'static> for Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
+        let close_on_drop = config.close_on_drop.unwrap_or(true);
         let fd = match config.raw_fd {
             Some(raw_fd) => raw_fd,
             _ => return Err(Error::InvalidConfig),
         };
         let device = {
             let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
-            let tun = Fd::new(fd).map_err(|_| std::io::Error::last_os_error())?;
+            let tun = Fd::new(fd, close_on_drop).map_err(|_| std::io::Error::last_os_error())?;
 
             Device {
                 tun: Tun::new(tun, mtu, false),

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -42,14 +42,14 @@ impl AsMut<dyn AbstractDevice + 'static> for Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
-        let close_on_drop = config.close_on_drop.unwrap_or(true);
+        let close_fd_on_drop = config.close_fd_on_drop.unwrap_or(true);
         let fd = match config.raw_fd {
             Some(raw_fd) => raw_fd,
             _ => return Err(Error::InvalidConfig),
         };
         let device = {
             let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
-            let tun = Fd::new(fd, close_on_drop).map_err(|_| std::io::Error::last_os_error())?;
+            let tun = Fd::new(fd, close_fd_on_drop).map_err(|_| std::io::Error::last_os_error())?;
 
             Device {
                 tun: Tun::new(tun, mtu, false),

--- a/src/platform/freebsd/device.rs
+++ b/src/platform/freebsd/device.rs
@@ -86,13 +86,13 @@ impl Device {
                 return Err(Error::InvalidQueuesNumber);
             }
 
-            let ctl = Fd::new(libc::socket(AF_INET, SOCK_DGRAM, 0))?;
+            let ctl = Fd::new(libc::socket(AF_INET, SOCK_DGRAM, 0), true)?;
 
             let (tun, tun_name) = {
                 if let Some(name) = dev.as_ref() {
                     let device_path = format!("/dev/{}\0", name);
                     let fd = libc::open(device_path.as_ptr() as *const _, O_RDWR);
-                    let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
+                    let tun = Fd::new(fd, true).map_err(|_| io::Error::last_os_error())?;
                     (tun, name.clone())
                 } else {
                     let (tun, device_name) = 'End: {
@@ -101,7 +101,8 @@ impl Device {
                             let device_path = format!("/dev/{device_name}\0");
                             let fd = libc::open(device_path.as_ptr() as *const _, O_RDWR);
                             if fd > 0 {
-                                let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
+                                let tun =
+                                    Fd::new(fd, true).map_err(|_| io::Error::last_os_error())?;
                                 break 'End (tun, device_name);
                             }
                         }

--- a/src/platform/ios/device.rs
+++ b/src/platform/ios/device.rs
@@ -45,13 +45,14 @@ impl AsMut<dyn AbstractDevice + 'static> for Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
+        let close_on_drop = config.close_on_drop.unwrap_or(true);
         let fd = match config.raw_fd {
             Some(raw_fd) => raw_fd,
             _ => return Err(Error::InvalidConfig),
         };
         let device = {
             let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
-            let fd = Fd::new(fd).map_err(|_| std::io::Error::last_os_error())?;
+            let fd = Fd::new(fd, close_on_drop).map_err(|_| std::io::Error::last_os_error())?;
             Device {
                 tun: Tun::new(fd, mtu, config.platform_config.packet_information),
             }

--- a/src/platform/ios/device.rs
+++ b/src/platform/ios/device.rs
@@ -45,14 +45,14 @@ impl AsMut<dyn AbstractDevice + 'static> for Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
-        let close_on_drop = config.close_on_drop.unwrap_or(true);
+        let close_fd_on_drop = config.close_fd_on_drop.unwrap_or(true);
         let fd = match config.raw_fd {
             Some(raw_fd) => raw_fd,
             _ => return Err(Error::InvalidConfig),
         };
         let device = {
             let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
-            let fd = Fd::new(fd, close_on_drop).map_err(|_| std::io::Error::last_os_error())?;
+            let fd = Fd::new(fd, close_fd_on_drop).map_err(|_| std::io::Error::last_os_error())?;
             Device {
                 tun: Tun::new(fd, mtu, config.platform_config.packet_information),
             }

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -58,7 +58,11 @@ impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
         let mut device = unsafe {
-            let dev = match config.tun_name.as_ref() {
+            if config.raw_fd.is_some() {
+                // TODO: Should we support this in the future?
+                return Err(Error::NotImplemented);
+            }
+            let dev_name = match config.tun_name.as_ref() {
                 Some(tun_name) => {
                     let tun_name = CString::new(tun_name.clone())?;
 
@@ -74,11 +78,11 @@ impl Device {
 
             let mut req: ifreq = mem::zeroed();
 
-            if let Some(dev) = dev.as_ref() {
+            if let Some(dev_name) = dev_name.as_ref() {
                 ptr::copy_nonoverlapping(
-                    dev.as_ptr() as *const c_char,
+                    dev_name.as_ptr() as *const c_char,
                     req.ifr_name.as_mut_ptr(),
-                    dev.as_bytes().len(),
+                    dev_name.as_bytes_with_nul().len(),
                 );
             }
 
@@ -96,15 +100,15 @@ impl Device {
                 | if packet_information { 0 } else { iff_no_pi }
                 | if queues_num > 1 { iff_multi_queue } else { 0 };
 
-            let tun = {
+            let tun_fd = {
                 let fd = libc::open(b"/dev/net/tun\0".as_ptr() as *const _, O_RDWR);
-                let tun = Fd::new(fd, true).map_err(|_| io::Error::last_os_error())?;
+                let tun_fd = Fd::new(fd, true).map_err(|_| io::Error::last_os_error())?;
 
-                if let Err(err) = tunsetiff(tun.inner, &mut req as *mut _ as *mut _) {
+                if let Err(err) = tunsetiff(tun_fd.inner, &mut req as *mut _ as *mut _) {
                     return Err(io::Error::from(err).into());
                 }
 
-                tun
+                tun_fd
             };
 
             let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
@@ -116,7 +120,7 @@ impl Device {
                 .to_string();
             Device {
                 tun_name,
-                tun: Tun::new(tun, mtu, packet_information),
+                tun: Tun::new(tun_fd, mtu, packet_information),
                 ctl,
             }
         };

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -96,9 +96,9 @@ impl Device {
 
             let tun = {
                 let fd = libc::open(b"/dev/net/tun\0".as_ptr() as *const _, O_RDWR);
-                let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
+                let tun = Fd::new(fd, true).map_err(|_| io::Error::last_os_error())?;
 
-                if let Err(err) = tunsetiff(tun.0, &mut req as *mut _ as *mut _) {
+                if let Err(err) = tunsetiff(tun.inner, &mut req as *mut _ as *mut _) {
                     return Err(io::Error::from(err).into());
                 }
 
@@ -107,7 +107,7 @@ impl Device {
 
             let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
 
-            let ctl = Fd::new(libc::socket(AF_INET, SOCK_DGRAM, 0))?;
+            let ctl = Fd::new(libc::socket(AF_INET, SOCK_DGRAM, 0), true)?;
 
             let tun_name = CStr::from_ptr(req.ifr_name.as_ptr())
                 .to_string_lossy()

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -19,7 +19,7 @@ use crate::{
     error::{Error, Result},
     platform::{
         macos::sys::*,
-        posix::{self, ipaddr_to_sockaddr, sockaddr_to_rs_addr, sockaddr_union},
+        posix::{self, ipaddr_to_sockaddr, sockaddr_to_rs_addr, sockaddr_union, Fd},
     },
 };
 
@@ -70,8 +70,8 @@ impl Device {
     pub fn new(config: &Configuration) -> Result<Self> {
         let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
         if let Some(fd) = config.raw_fd {
-            let close_on_drop = config.close_on_drop.unwrap_or(true);
-            let tun = posix::Fd::new(fd, close_on_drop).map_err(|_| io::Error::last_os_error())?;
+            let close_fd_on_drop = config.close_fd_on_drop.unwrap_or(true);
+            let tun = Fd::new(fd, close_fd_on_drop).map_err(|_| io::Error::last_os_error())?;
             let device = Device {
                 tun_name: None,
                 tun: posix::Tun::new(tun, mtu, config.platform_config.packet_information),

--- a/src/platform/macos/device.rs
+++ b/src/platform/macos/device.rs
@@ -68,7 +68,8 @@ impl Device {
     pub fn new(config: &Configuration) -> Result<Self> {
         let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
         if let Some(fd) = config.raw_fd {
-            let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
+            let close_on_drop = config.close_on_drop.unwrap_or(true);
+            let tun = Fd::new(fd, close_on_drop).map_err(|_| io::Error::last_os_error())?;
             let device = Device {
                 tun_name: None,
                 tun: Tun::new(tun, mtu, config.platform_config.packet_information),
@@ -103,7 +104,7 @@ impl Device {
 
         let mut device = unsafe {
             let fd = libc::socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL);
-            let tun = Fd::new(fd).map_err(|_| io::Error::last_os_error())?;
+            let tun = Fd::new(fd, true).map_err(|_| io::Error::last_os_error())?;
 
             let mut info = ctl_info {
                 ctl_id: 0,
@@ -116,7 +117,7 @@ impl Device {
                 },
             };
 
-            if let Err(err) = ctliocginfo(tun.0, &mut info as *mut _ as *mut _) {
+            if let Err(err) = ctliocginfo(tun.inner, &mut info as *mut _ as *mut _) {
                 return Err(io::Error::from(err).into());
             }
 
@@ -130,7 +131,7 @@ impl Device {
             };
 
             let address = &addr as *const libc::sockaddr_ctl as *const sockaddr;
-            if libc::connect(tun.0, address, mem::size_of_val(&addr) as socklen_t) < 0 {
+            if libc::connect(tun.inner, address, mem::size_of_val(&addr) as socklen_t) < 0 {
                 return Err(io::Error::last_os_error().into());
             }
 
@@ -139,11 +140,11 @@ impl Device {
 
             let optval = &mut tun_name as *mut _ as *mut c_void;
             let optlen = &mut name_len as *mut socklen_t;
-            if libc::getsockopt(tun.0, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, optval, optlen) < 0 {
+            if libc::getsockopt(tun.inner, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, optval, optlen) < 0 {
                 return Err(io::Error::last_os_error().into());
             }
 
-            let ctl = Some(Fd::new(libc::socket(AF_INET, SOCK_DGRAM, 0))?);
+            let ctl = Some(Fd::new(libc::socket(AF_INET, SOCK_DGRAM, 0), true)?);
 
             Device {
                 tun_name: Some(

--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -18,20 +18,25 @@ use std::io;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 
 /// POSIX file descriptor support for `io` traits.
-#[repr(transparent)]
-pub(crate) struct Fd(pub(crate) RawFd);
+pub(crate) struct Fd {
+    pub(crate) inner: RawFd,
+    close_on_drop: bool,
+}
 
 impl Fd {
-    pub fn new(value: RawFd) -> Result<Self> {
+    pub fn new(value: RawFd, close_on_drop: bool) -> Result<Self> {
         if value < 0 {
             return Err(Error::InvalidDescriptor);
         }
-        Ok(Fd(value))
+        Ok(Fd {
+            inner: value,
+            close_on_drop,
+        })
     }
 
     /// Enable non-blocking mode
     pub fn set_nonblock(&self) -> io::Result<()> {
-        match unsafe { fcntl(self.0, F_SETFL, fcntl(self.0, F_GETFL) | O_NONBLOCK) } {
+        match unsafe { fcntl(self.inner, F_SETFL, fcntl(self.inner, F_GETFL) | O_NONBLOCK) } {
             0 => Ok(()),
             _ => Err(io::Error::last_os_error()),
         }
@@ -58,22 +63,22 @@ impl Fd {
 
 impl AsRawFd for Fd {
     fn as_raw_fd(&self) -> RawFd {
-        self.0
+        self.inner
     }
 }
 
 impl IntoRawFd for Fd {
     fn into_raw_fd(mut self) -> RawFd {
-        let fd = self.0;
-        self.0 = -1;
+        let fd = self.inner;
+        self.inner = -1;
         fd
     }
 }
 
 impl Drop for Fd {
     fn drop(&mut self) {
-        if self.0 >= 0 {
-            unsafe { libc::close(self.0) };
+        if self.close_on_drop && self.inner >= 0 {
+            unsafe { libc::close(self.inner) };
         }
     }
 }

--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -20,17 +20,17 @@ use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 /// POSIX file descriptor support for `io` traits.
 pub(crate) struct Fd {
     pub(crate) inner: RawFd,
-    close_on_drop: bool,
+    close_fd_on_drop: bool,
 }
 
 impl Fd {
-    pub fn new(value: RawFd, close_on_drop: bool) -> Result<Self> {
+    pub fn new(value: RawFd, close_fd_on_drop: bool) -> Result<Self> {
         if value < 0 {
             return Err(Error::InvalidDescriptor);
         }
         Ok(Fd {
             inner: value,
-            close_on_drop,
+            close_fd_on_drop,
         })
     }
 
@@ -77,7 +77,7 @@ impl IntoRawFd for Fd {
 
 impl Drop for Fd {
     fn drop(&mut self) {
-        if self.close_on_drop && self.inner >= 0 {
+        if self.close_fd_on_drop && self.inner >= 0 {
             unsafe { libc::close(self.inner) };
         }
     }


### PR DESCRIPTION
When the file descriptor is provided via the configuration, it is not necessarily true that the file descriptor should be closed by the tun2 library, as it might be used outside of its scope.

To enable more flexibility, configure whether the closing should happen in the library or be left as the responsability of the user.