### PR TITLE
Add support for dynamic Wintun library loading and update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 wintun.dll
+.history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ nix = { version = "0.29", features = ["ioctl"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wintun = { version = "0.4", features = ["panic_on_unsent_packets"] }
+libloading = "0.8.3"
 
 [target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
 ipnet = "2"

--- a/README.md
+++ b/README.md
@@ -135,4 +135,5 @@ pub extern "C" fn start_tun(fd: std::os::raw::c_int) {
 Windows
 -----
 You need to copy the [wintun.dll](https://wintun.net/) file which matches your architecture to 
-the same directory as your executable and run your program as administrator.
+the same directory as your executable or can set `WINTUN_LIBARAY_PATH` to the dll file and run your program as administrator.
+

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,10 @@ pub enum Error {
     #[cfg(target_os = "windows")]
     #[error(transparent)]
     WintunError(#[from] wintun::Error),
+
+    #[cfg(target_os = "windows")]
+    #[error(transparent)]
+    LibloadingError(#[from] libloading::Error),
 }
 
 impl From<Error> for std::io::Error {

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -12,6 +12,7 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
+use std::env;
 use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -31,7 +32,12 @@ pub struct Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
-        let wintun = unsafe { wintun::load()? };
+        let wintun = unsafe {
+            let wintun_libray_path =
+                env::var("WINTUN_LIBARAY_PATH").unwrap_or("wintun.dll".to_string());
+            let wintun = libloading::Library::new(wintun_libray_path)?;
+            wintun::load_from_library(wintun)?
+        };
         let tun_name = config.tun_name.as_deref().unwrap_or("wintun");
         let guid = config.platform_config.device_guid;
         let adapter = match wintun::Adapter::open(&wintun, tun_name) {

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -12,7 +12,6 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-use std::env;
 use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -34,7 +33,7 @@ impl Device {
     pub fn new(config: &Configuration) -> Result<Self> {
         let wintun = unsafe {
             let wintun_libray_path =
-                env::var("WINTUN_LIBARAY_PATH").unwrap_or("wintun.dll".to_string());
+                std::env::var("WINTUN_LIBARAY_PATH").unwrap_or("wintun.dll".to_string());
             let wintun = libloading::Library::new(wintun_libray_path)?;
             wintun::load_from_library(wintun)?
         };


### PR DESCRIPTION
- Updated .gitignore to include .history directory
- Added `libloading` dependency to `Cargo.toml` for dynamic library loading
- Modified `README.md` to include instructions for setting `WINTUN_LIBARAY_PATH` environment variable
- Updated `Error` enum in `src/error.rs` to handle `libloading::Error`
- Modified `Device` struct in `src/platform/windows/device.rs` to dynamically load Wintun library using `libloading`