### PR TITLE
Make dynamic wintun as an optional feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 wintun.dll
+.history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ nix = { version = "0.29", features = ["ioctl"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wintun = { version = "0.4", features = ["panic_on_unsent_packets"] }
+libloading = "0.8.3"
 
 [target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
 ipnet = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ nix = { version = "0.29", features = ["ioctl"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wintun = { version = "0.4", features = ["panic_on_unsent_packets"] }
-libloading = "0.8.3"
+libloading = { version = "0.8.3", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
 ipnet = "2"
@@ -45,6 +45,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 [features]
 default = []
 async = ["tokio", "futures-core", "tokio-util"]
+dynamic-wintun = ["libloading"]
 
 [[example]]
 name = "read-async"

--- a/README.md
+++ b/README.md
@@ -135,4 +135,5 @@ pub extern "C" fn start_tun(fd: std::os::raw::c_int) {
 Windows
 -----
 You need to copy the [wintun.dll](https://wintun.net/) file which matches your architecture to 
-the same directory as your executable and run your program as administrator.
+the same directory as your executable or can set `WINTUN_LIBARAY_PATH` to the dll file and run your program as administrator.
+

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ pub extern "C" fn start_tun(fd: std::os::raw::c_int) {
 
 Windows
 -----
-You need to copy the [wintun.dll](https://wintun.net/) file which matches your architecture to 
-the same directory as your executable or can set `WINTUN_LIBARAY_PATH` to the dll file and run your program as administrator.
+To run your program successfully, you have two options:
 
+1. Place the [wintun.dll](https://wintun.net/) file, corresponding to your architecture, in the same directory as your executable.
+2. Alternatively, you can enable the `dynamic-wintun` feature and set the `WINTUN_LIBRARY_PATH` environment variable to point to the DLL file. Then, execute your program as an administrator.

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,10 @@ pub enum Error {
     #[cfg(target_os = "windows")]
     #[error(transparent)]
     WintunError(#[from] wintun::Error),
+
+    #[cfg(target_os = "windows")]
+    #[error(transparent)]
+    LibloadingError(#[from] libloading::Error),
 }
 
 impl From<Error> for std::io::Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,7 @@ pub enum Error {
     #[error(transparent)]
     WintunError(#[from] wintun::Error),
 
-    #[cfg(target_os = "windows")]
+    #[cfg(all(target_os = "windows", feature = "dynamic-wintun"))]
     #[error(transparent)]
     LibloadingError(#[from] libloading::Error),
 }

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -12,6 +12,7 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
+use std::env;
 use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -31,7 +32,12 @@ pub struct Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
-        let wintun = unsafe { wintun::load()? };
+        let wintun = unsafe {
+            let wintun_libray_path =
+                env::var("WINTUN_LIBARAY_PATH").unwrap_or("wintun.dll".to_string());
+            let wintun = libloading::Library::new(wintun_libray_path)?;
+            wintun::load_from_library(wintun)?
+        };
         let tun_name = config.tun_name.as_deref().unwrap_or("wintun");
         let guid = config.platform_config.device_guid;
         let adapter = match wintun::Adapter::open(&wintun, tun_name) {

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -12,7 +12,6 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-use std::env;
 use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;


### PR DESCRIPTION
Now if need to use dynamic wintun loading via environment variable need to enable the `dynamic-wintun` feature while building.