### PR TITLE
Support custom wintun.dll paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ target/
 **/*.rs.bk
 Cargo.lock
 wintun.dll
-.history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ nix = { version = "0.29", features = ["ioctl"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wintun = { version = "0.4", features = ["panic_on_unsent_packets"] }
-libloading = "0.8.3"
 
 [target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
 ipnet = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ nix = { version = "0.29", features = ["ioctl"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wintun = { version = "0.4", features = ["panic_on_unsent_packets"] }
+libloading = "0.8"
 
 [target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
 ipnet = "2"

--- a/README.md
+++ b/README.md
@@ -135,5 +135,4 @@ pub extern "C" fn start_tun(fd: std::os::raw::c_int) {
 Windows
 -----
 You need to copy the [wintun.dll](https://wintun.net/) file which matches your architecture to 
-the same directory as your executable or can set `WINTUN_LIBARAY_PATH` to the dll file and run your program as administrator.
-
+the same directory as your executable and run your program as administrator.

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,10 @@ pub enum Error {
     #[cfg(target_os = "windows")]
     #[error(transparent)]
     WintunError(#[from] wintun::Error),
+
+    #[cfg(target_os = "windows")]
+    #[error(transparent)]
+    LibloadingError(#[from] libloading::Error),
 }
 
 impl From<Error> for std::io::Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,10 +53,6 @@ pub enum Error {
     #[cfg(target_os = "windows")]
     #[error(transparent)]
     WintunError(#[from] wintun::Error),
-
-    #[cfg(target_os = "windows")]
-    #[error(transparent)]
-    LibloadingError(#[from] libloading::Error),
 }
 
 impl From<Error> for std::io::Error {

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -31,7 +31,14 @@ pub struct Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
-        let wintun = unsafe { wintun::load()? };
+        let wintun_path = match &config.platform_config.wintun_path {
+            Some(path) => path.clone(),
+            None => "wintun.dll".to_string(),
+        };
+        let wintun = unsafe {
+            let wintun = libloading::Library::new(wintun_path)?;
+            wintun::load_from_library(wintun)?
+        };
         let tun_name = config.tun_name.as_deref().unwrap_or("wintun");
         let guid = config.platform_config.device_guid;
         let adapter = match wintun::Adapter::open(&wintun, tun_name) {

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -31,12 +31,7 @@ pub struct Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
-        let wintun = unsafe {
-            let wintun_libray_path =
-                std::env::var("WINTUN_LIBARAY_PATH").unwrap_or("wintun.dll".to_string());
-            let wintun = libloading::Library::new(wintun_libray_path)?;
-            wintun::load_from_library(wintun)?
-        };
+        let wintun = unsafe { wintun::load()? };
         let tun_name = config.tun_name.as_deref().unwrap_or("wintun");
         let guid = config.platform_config.device_guid;
         let adapter = match wintun::Adapter::open(&wintun, tun_name) {

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -22,15 +22,23 @@ use crate::configuration::Configuration;
 use crate::error::Result;
 
 /// Windows-only interface configuration.
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct PlatformConfig {
     pub(crate) device_guid: Option<u128>,
+    pub(crate) wintun_path: Option<String>,
 }
 
 impl PlatformConfig {
     pub fn device_guid(&mut self, device_guid: Option<u128>) {
         log::trace!("Windows configuration device GUID");
         self.device_guid = device_guid;
+    }
+
+    /// Use a custom path to the wintun.dll instead of looking in the working directory.
+    /// Security note: It is up to the caller to ensure that the library can be safely loaded from
+    /// the indicated path.
+    pub fn custom_wintun_path(&mut self, wintun_path: Option<String>) {
+        self.wintun_path = wintun_path;
     }
 }
 


### PR DESCRIPTION
Instead of the previous approach using an environment variable, this approach leaves it to the caller to specify a custom path to the `wintun.dll`.

This approach has the following advantages:
1. In contrast to the origin of information in environment variables, the security context of the origin data is clear.
2. There are no security-related changes for existing users of the library.