### PR TITLE
Support set wintun dns servers

### DIFF
--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -54,6 +54,9 @@ impl Device {
             .unwrap_or(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 0)));
         let gateway = config.destination.map(IpAddr::from);
         adapter.set_network_addresses_tuple(address, mask, gateway)?;
+        if let Some(dns_servers) = &config.platform_config.dns_servers {
+            adapter.set_dns_servers(dns_servers)?;
+        }
         let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
 
         let session = adapter.start_session(wintun::MAX_RING_CAPACITY)?;

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -16,6 +16,8 @@
 
 mod device;
 
+use std::net::IpAddr;
+
 pub use device::{Device, Tun};
 
 use crate::configuration::Configuration;
@@ -26,6 +28,7 @@ use crate::error::Result;
 pub struct PlatformConfig {
     pub(crate) device_guid: Option<u128>,
     pub(crate) wintun_path: Option<String>,
+    pub(crate) dns_servers: Option<Vec<IpAddr>>,
 }
 
 impl PlatformConfig {
@@ -39,6 +42,10 @@ impl PlatformConfig {
     /// the indicated path.
     pub fn custom_wintun_path(&mut self, wintun_path: Option<String>) {
         self.wintun_path = wintun_path;
+    }
+
+    pub fn dns_servers(&mut self, dns_servers: Option<Vec<IpAddr>>) {
+        self.dns_servers = dns_servers;
     }
 }
 


### PR DESCRIPTION
Add windows platform configuration to set wintun dns servers when created tun device