### PR TITLE
Refine windows platform configuration

### DIFF
--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -31,9 +31,9 @@ pub struct Device {
 impl Device {
     /// Create a new `Device` for the given `Configuration`.
     pub fn new(config: &Configuration) -> Result<Self> {
-        let wintun_path = &config.platform_config.wintun_path;
+        let wintun_file = &config.platform_config.wintun_file;
         let wintun = unsafe {
-            let wintun = libloading::Library::new(wintun_path)?;
+            let wintun = libloading::Library::new(wintun_file)?;
             wintun::load_from_library(wintun)?
         };
         let tun_name = config.tun_name.as_deref().unwrap_or("wintun");

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -16,33 +16,36 @@
 
 mod device;
 
-use std::ffi::OsString;
-use std::net::IpAddr;
-
-pub use device::{Device, Tun};
-
 use crate::configuration::Configuration;
 use crate::error::Result;
+pub use device::{Device, Tun};
+use std::ffi::OsString;
+use std::net::IpAddr;
 
 /// Windows-only interface configuration.
 #[derive(Clone, Debug)]
 pub struct PlatformConfig {
-    pub(crate) wintun_file: OsString,
     pub(crate) device_guid: Option<u128>,
+    pub(crate) wintun_file: OsString,
     pub(crate) dns_servers: Option<Vec<IpAddr>>,
 }
 
 impl Default for PlatformConfig {
     fn default() -> Self {
         Self {
-            wintun_file: "wintun".into(),
             device_guid: None,
+            wintun_file: "wintun.dll".into(),
             dns_servers: None,
         }
     }
 }
 
 impl PlatformConfig {
+    pub fn device_guid(&mut self, device_guid: u128) {
+        log::trace!("Windows configuration device GUID");
+        self.device_guid = Some(device_guid);
+    }
+
     /// Use a custom path to the wintun.dll instead of looking in the working directory.
     /// Security note: It is up to the caller to ensure that the library can be safely loaded from
     /// the indicated path.
@@ -52,13 +55,8 @@ impl PlatformConfig {
         self.wintun_file = wintun_file.into();
     }
 
-    pub fn device_guid(&mut self, device_guid: u128) {
-        log::trace!("Windows configuration device GUID");
-        self.device_guid = Some(device_guid);
-    }
-
-    pub fn dns_servers(&mut self, dns_servers: Vec<IpAddr>) {
-        self.dns_servers = Some(dns_servers);
+    pub fn dns_servers(&mut self, dns_servers: &[IpAddr]) {
+        self.dns_servers = Some(dns_servers.to_vec());
     }
 }
 


### PR DESCRIPTION
- Move `wintun_path` to `wintun_file`, which makes the options clearer.
- Use `Into<OsString>` instead of `&str`, which is consistent with `libloading` so that platform native strings can be passed.
- Replace optional argument of the method `dns_servers` to an inner actual value.
