### PR TITLE
Allow to set MTU on Windows platform

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -116,10 +116,7 @@ impl Configuration {
     ///
     /// [Note: mtu on the Windows platform is always 65535 due to wintun -- end note]
     pub fn mtu(&mut self, value: u16) -> &mut Self {
-        // mtu on windows platform is always 65535 due to wintun
-        if cfg!(target_family = "unix") {
-            self.mtu = Some(value);
-        }
+        self.mtu = Some(value);
         self
     }
 

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -54,6 +54,9 @@ impl Device {
             .unwrap_or(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 0)));
         let gateway = config.destination.map(IpAddr::from);
         adapter.set_network_addresses_tuple(address, mask, gateway)?;
+        if let Some(dns_servers) = &config.platform_config.dns_servers {
+            adapter.set_dns_servers(dns_servers)?;
+        }
         let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
 
         let session = adapter.start_session(wintun::MAX_RING_CAPACITY)?;

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -67,6 +67,7 @@ impl Device {
             adapter.set_dns_servers(dns_servers)?;
         }
         let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
+        adapter.set_mtu(mtu as usize)?;
 
         let session = adapter.start_session(wintun::MAX_RING_CAPACITY)?;
 
@@ -201,7 +202,6 @@ impl AbstractDevice for Device {
 
     /// The return value is always `Ok(65535)` due to wintun
     fn mtu(&self) -> Result<u16> {
-        // Note: wintun mtu is always 65535
         Ok(self.mtu)
     }
 

--- a/src/platform/windows/device.rs
+++ b/src/platform/windows/device.rs
@@ -28,8 +28,6 @@ use crate::platform::windows::verify_dll_file::{
 /// A TUN device using the wintun driver.
 pub struct Device {
     pub(crate) tun: Tun,
-    #[allow(unused)]
-    mtu: u16,
 }
 
 impl Device {
@@ -67,7 +65,6 @@ impl Device {
         if let Some(dns_servers) = &config.platform_config.dns_servers {
             adapter.set_dns_servers(dns_servers)?;
         }
-        let mtu = config.mtu.unwrap_or(crate::DEFAULT_MTU);
 
         let session = adapter.start_session(wintun::MAX_RING_CAPACITY)?;
 
@@ -76,10 +73,8 @@ impl Device {
                 session: Arc::new(session),
                 adapter,
             },
-            mtu,
         };
 
-        // This is not needed since we use netsh to set the address.
         device.configure(config)?;
 
         Ok(device)

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -16,6 +16,8 @@
 
 mod device;
 
+use std::net::IpAddr;
+
 pub use device::{Device, Tun};
 
 use crate::configuration::Configuration;
@@ -26,6 +28,7 @@ use crate::error::Result;
 pub struct PlatformConfig {
     pub(crate) device_guid: Option<u128>,
     pub(crate) wintun_path: Option<String>,
+    pub(crate) dns_servers: Option<Vec<IpAddr>>,
 }
 
 impl PlatformConfig {
@@ -39,6 +42,10 @@ impl PlatformConfig {
     /// the indicated path.
     pub fn custom_wintun_path(&mut self, wintun_path: Option<String>) {
         self.wintun_path = wintun_path;
+    }
+
+    pub fn dns_servers(&mut self, dns_servers: Option<Vec<IpAddr>>) {
+        self.dns_servers = dns_servers;
     }
 }
 


### PR DESCRIPTION
https://github.com/tun2proxy/rust-tun/blob/v2/src/platform/windows/device.rs#L208
<img width="799" alt="image" src="https://github.com/tun2proxy/rust-tun/assets/5327802/c809e934-183d-4983-84ec-cb63a7e0a652">
I think the MTU should be allowed to configure