### PR TITLE
Fix ios and android builds 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,8 @@ jobs:
       run: echo "Some of jobs failed" && false
 
   build_n_test_android:
+    strategy:
+      fail-fast: false
     runs-on: ubuntu-latest
 
     steps:
@@ -52,6 +54,8 @@ jobs:
       run: echo "Android build job failed" && false
 
   build_n_test_ios:
+    strategy:
+      fail-fast: false
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,6 +51,24 @@ jobs:
       if: ${{ failure() }}
       run: echo "Android build job failed" && false
 
+  build_n_test_ios:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install cargo lipo and rust compiler for ios target
+      if: ${{ !cancelled() }}
+      run: |
+        cargo install --locked cargo-lipo
+        rustup target add x86_64-apple-ios aarch64-apple-ios
+    - name: Build
+      if: ${{ !cancelled() }}
+      run: |
+        cargo lipo --verbose --all-features --features="async tokio/rt-multi-thread"
+    - name: Abort on error
+      if: ${{ failure() }}
+      run: echo "iOs build job failed" && false
+
   semver:
     name: Check semver
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,24 @@ jobs:
       if: ${{ failure() }}
       run: echo "Some of jobs failed" && false
 
+  build_n_test_android:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install cargo ndk and rust compiler for android target
+      if: ${{ !cancelled() }}
+      run: |
+        cargo install --locked cargo-ndk
+        rustup target add x86_64-linux-android
+    - name: Build
+      if: ${{ !cancelled() }}
+      run: |
+        cargo ndk -t x86_64 rustc --verbose --all-features --features="async tokio/rt-multi-thread" --lib --crate-type=cdylib
+    - name: Abort on error
+      if: ${{ failure() }}
+      run: echo "Android build job failed" && false
+
   semver:
     name: Check semver
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,9 @@ jobs:
       run: |
         cargo install --locked cargo-ndk
         rustup target add x86_64-linux-android
+    - name: clippy
+      if: ${{ !cancelled() }}
+      run: cargo ndk -t x86_64 clippy --all-features --features="async tokio/rt-multi-thread" -- -D warnings
     - name: Build
       if: ${{ !cancelled() }}
       run: |
@@ -65,6 +68,9 @@ jobs:
       run: |
         cargo install --locked cargo-lipo
         rustup target add x86_64-apple-ios aarch64-apple-ios
+    - name: clippy
+      if: ${{ !cancelled() }}
+      run: cargo clippy --target x86_64-apple-ios --all-features --features="async tokio/rt-multi-thread" -- -D warnings
     - name: Build
       if: ${{ !cancelled() }}
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun2"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 authors = ["meh. <meh@schizofreni.co>", "@ssrlive"]
 license = "WTFPL"

--- a/src/platform/android/device.rs
+++ b/src/platform/android/device.rs
@@ -70,12 +70,12 @@ impl Device {
     }
 
     /// Recv a packet from tun device
-    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+    pub fn recv(&self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.tun.recv(buf)
     }
 
     /// Send a packet to tun device
-    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+    pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.tun.send(buf)
     }
 }

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -26,5 +26,5 @@ pub struct PlatformConfig;
 
 /// Create a TUN device with the given name.
 pub fn create(configuration: &Configuration) -> Result<Device> {
-    Device::new(&configuration)
+    Device::new(configuration)
 }

--- a/src/platform/ios/device.rs
+++ b/src/platform/ios/device.rs
@@ -72,12 +72,12 @@ impl Device {
     }
 
     /// Recv a packet from tun device
-    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+    pub fn recv(&self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.tun.recv(buf)
     }
 
     /// Send a packet to tun device
-    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+    pub fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
         self.tun.send(buf)
     }
 }

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -55,5 +55,5 @@ impl PlatformConfig {
 
 /// Create a TUN device with the given name.
 pub fn create(configuration: &Configuration) -> Result<Device> {
-    Device::new(&configuration)
+    Device::new(configuration)
 }

--- a/src/platform/posix/mod.rs
+++ b/src/platform/posix/mod.rs
@@ -15,7 +15,11 @@
 //! POSIX compliant support.
 
 mod sockaddr;
-pub(crate) use sockaddr::{ipaddr_to_sockaddr, sockaddr_union};
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+pub(crate) use sockaddr::sockaddr_union;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) use sockaddr::ipaddr_to_sockaddr;
 
 mod fd;
 pub(crate) use self::fd::Fd;

--- a/src/platform/posix/sockaddr.rs
+++ b/src/platform/posix/sockaddr.rs
@@ -60,7 +60,8 @@ fn rs_addr_to_sockaddr(addr: std::net::SocketAddr) -> sockaddr_union {
 
 /// # Safety
 /// Fill the `addr` with the `src_addr` and `src_port`, the `size` should be the size of overwriting
-pub unsafe fn ipaddr_to_sockaddr<T>(
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) unsafe fn ipaddr_to_sockaddr<T>(
     src_addr: T,
     src_port: u16,
     addr: &mut libc::sockaddr,


### PR DESCRIPTION
When adding support for async send/recv apis in https://github.com/tun2proxy/rust-tun/pull/87 , ios and android builds got broken with following error

```
error[E0433]: failed to resolve: use of undeclared crate or module `io`
```

**Root cause:**

Both ios and android platform code did not import `std::io::self` which caused it to fail. 

This PR attempts to fix those issues.

Also I have added CI jobs to build Android and iOS targets, to find these issues earlier

Example of test fail without the fix:
https://github.com/kp-mariappan-ramasamy/rust-tun/actions/runs/10058442720/job/27801536723#step:4:95
https://github.com/kp-mariappan-ramasamy/rust-tun/actions/runs/10058442720/job/27801536214#step:4:110