### PR TITLE
Impl Deref/DerefMut traits for AsyncDevice

### DIFF
--- a/examples/read-async.rs
+++ b/examples/read-async.rs
@@ -46,7 +46,7 @@ async fn main_entry(mut quit: Receiver<()>) -> Result<(), BoxError> {
     });
 
     let mut dev = tun2::create_as_async(&config)?;
-    let size = dev.as_ref().mtu()? as usize + tun2::PACKET_INFORMATION_LENGTH;
+    let size = dev.mtu()? as usize + tun2::PACKET_INFORMATION_LENGTH;
     let mut buf = vec![0; size];
     loop {
         tokio::select! {

--- a/src/async/unix_device.rs
+++ b/src/async/unix_device.rs
@@ -30,16 +30,18 @@ pub struct AsyncDevice {
     inner: AsyncFd<Device>,
 }
 
-/// Returns a shared reference to the underlying Device object
-impl AsRef<Device> for AsyncDevice {
-    fn as_ref(&self) -> &Device {
+/// Returns a shared reference to the underlying Device object.
+impl core::ops::Deref for AsyncDevice {
+    type Target = Device;
+
+    fn deref(&self) -> &Self::Target {
         self.inner.get_ref()
     }
 }
 
-/// Returns a mutable reference to the underlying Device object
-impl AsMut<Device> for AsyncDevice {
-    fn as_mut(&mut self) -> &mut Device {
+/// Returns a mutable reference to the underlying Device object.
+impl core::ops::DerefMut for AsyncDevice {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.get_mut()
     }
 }
@@ -55,7 +57,7 @@ impl AsyncDevice {
 
     /// Consumes this AsyncDevice and return a Framed object (unified Stream and Sink interface)
     pub fn into_framed(self) -> Framed<Self, TunPacketCodec> {
-        let mtu = self.as_ref().mtu().unwrap_or(crate::DEFAULT_MTU);
+        let mtu = self.mtu().unwrap_or(crate::DEFAULT_MTU);
         let codec = TunPacketCodec::new(mtu as usize);
         // associate mtu with the capacity of ReadBuf
         Framed::with_capacity(self, codec, mtu as usize)

--- a/src/async/win_device.rs
+++ b/src/async/win_device.rs
@@ -24,21 +24,24 @@ use super::TunPacketCodec;
 use crate::device::AbstractDevice;
 use crate::platform::Device;
 
+/// An async TUN device wrapper around a TUN device.
 pub struct AsyncDevice {
     inner: Device,
     session: WinSession,
 }
 
-/// Returns a shared reference to the underlying Device object
-impl AsRef<Device> for AsyncDevice {
-    fn as_ref(&self) -> &Device {
+/// Returns a shared reference to the underlying Device object.
+impl core::ops::Deref for AsyncDevice {
+    type Target = Device;
+
+    fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-/// Returns a mutable reference to the underlying Device object
-impl AsMut<Device> for AsyncDevice {
-    fn as_mut(&mut self) -> &mut Device {
+/// Returns a mutable reference to the underlying Device object.
+impl core::ops::DerefMut for AsyncDevice {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
@@ -55,7 +58,7 @@ impl AsyncDevice {
 
     /// Consumes this AsyncDevice and return a Framed object (unified Stream and Sink interface)
     pub fn into_framed(self) -> Framed<Self, TunPacketCodec> {
-        let mtu = self.as_ref().mtu().unwrap_or(crate::DEFAULT_MTU);
+        let mtu = self.mtu().unwrap_or(crate::DEFAULT_MTU);
         let codec = TunPacketCodec::new(mtu as usize);
         // guarantee to avoid the mtu of wintun may far away larger than the default provided capacity of ReadBuf of Framed
         Framed::with_capacity(self, codec, mtu as usize)


### PR DESCRIPTION
This allows us to simplify access to the public methods of the Device associated with AsyncDevice, and call Device methods directly on any reference that has an AsyncDevice. For example: previously `async_device.as_ref().mtu()` can now be `async_device.mtu()`.

See the thread in https://github.com/tun2proxy/rust-tun/issues/92 .