### PR TITLE
Linux: Support for IFF_NAPI and IFF_VNET_HDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Platforms
 
 Linux
 -----
-You will need the `tun2` module to be loaded and root is required to create
+You will need the `tun` module to be loaded and root is required to create
 interfaces.
 
 macOS & FreeBSD

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Platforms
 
 Linux
 -----
-You will need the `tun` module to be loaded and root is required to create
+You will need the `tun2` module to be loaded and root is required to create
 interfaces.
 
 macOS & FreeBSD

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -13,8 +13,8 @@
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
 use libc::{
-    self, c_char, c_short, ifreq, AF_INET, IFF_MULTI_QUEUE, IFF_NO_PI, IFF_RUNNING, IFF_TAP,
-    IFF_TUN, IFF_UP, IFNAMSIZ, O_RDWR, SOCK_DGRAM,
+    self, c_char, c_short, ifreq, AF_INET, IFF_MULTI_QUEUE, IFF_NAPI, IFF_NO_PI, IFF_RUNNING,
+    IFF_TAP, IFF_TUN, IFF_UP, IFNAMSIZ, O_RDWR, SOCK_DGRAM,
 };
 use std::{
     ffi::{CStr, CString},
@@ -105,10 +105,13 @@ impl Device {
 
             let iff_no_pi = IFF_NO_PI as c_short;
             let iff_multi_queue = IFF_MULTI_QUEUE as c_short;
+            let iff_napi = IFF_NAPI as c_short;
             let packet_information = config.platform_config.packet_information;
+            let napi = config.platform_config.napi;
             req.ifr_ifru.ifru_flags = device_type
                 | if packet_information { 0 } else { iff_no_pi }
-                | if queues_num > 1 { iff_multi_queue } else { 0 };
+                | if queues_num > 1 { iff_multi_queue } else { 0 }
+                | if napi { iff_napi } else { 0 };
 
             let tun_fd = {
                 let fd = libc::open(b"/dev/net/tun\0".as_ptr() as *const _, O_RDWR);

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -14,7 +14,7 @@
 
 use libc::{
     self, c_char, c_short, ifreq, AF_INET, IFF_MULTI_QUEUE, IFF_NAPI, IFF_NO_PI, IFF_RUNNING,
-    IFF_TAP, IFF_TUN, IFF_UP, IFNAMSIZ, O_RDWR, SOCK_DGRAM,
+    IFF_TAP, IFF_TUN, IFF_UP, IFF_VNET_HDR, IFNAMSIZ, O_RDWR, SOCK_DGRAM,
 };
 use std::{
     ffi::{CStr, CString},
@@ -106,12 +106,15 @@ impl Device {
             let iff_no_pi = IFF_NO_PI as c_short;
             let iff_multi_queue = IFF_MULTI_QUEUE as c_short;
             let iff_napi = IFF_NAPI as c_short;
+            let iff_vnet_hdr = IFF_VNET_HDR as c_short;
             let packet_information = config.platform_config.packet_information;
             let napi = config.platform_config.napi;
+            let vnet_hdr = config.platform_config.vnet_hdr;
             req.ifr_ifru.ifru_flags = device_type
                 | if packet_information { 0 } else { iff_no_pi }
                 | if queues_num > 1 { iff_multi_queue } else { 0 }
-                | if napi { iff_napi } else { 0 };
+                | if napi { iff_napi } else { 0 }
+                | if vnet_hdr { iff_vnet_hdr } else { 0 };
 
             let tun_fd = {
                 let fd = libc::open(b"/dev/net/tun\0".as_ptr() as *const _, O_RDWR);

--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -112,9 +112,9 @@ impl Device {
             let vnet_hdr = config.platform_config.vnet_hdr;
             req.ifr_ifru.ifru_flags = device_type
                 | if packet_information { 0 } else { iff_no_pi }
-                | if queues_num > 1 { iff_multi_queue } else { 0 }
                 | if napi { iff_napi } else { 0 }
-                | if vnet_hdr { iff_vnet_hdr } else { 0 };
+                | if vnet_hdr { iff_vnet_hdr } else { 0 }
+                | if queues_num > 1 { iff_multi_queue } else { 0 };
 
             let tun_fd = {
                 let fd = libc::open(b"/dev/net/tun\0".as_ptr() as *const _, O_RDWR);

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -29,6 +29,9 @@ pub struct PlatformConfig {
     pub(crate) packet_information: bool,
     /// root privileges required or not
     pub(crate) ensure_root_privileges: bool,
+
+    /// Enable IFF_NAPI
+    pub(crate) napi: bool,
 }
 
 /// `packet_information` is default to be `false` and `ensure_root_privileges` is default to be `true`.
@@ -37,6 +40,7 @@ impl Default for PlatformConfig {
         PlatformConfig {
             packet_information: false,
             ensure_root_privileges: true,
+            napi: false,
         }
     }
 }
@@ -59,6 +63,13 @@ impl PlatformConfig {
     /// since some operations need it such as assigning IP/netmask/destination etc.
     pub fn ensure_root_privileges(&mut self, value: bool) -> &mut Self {
         self.ensure_root_privileges = value;
+        self
+    }
+
+    /// Enable IFF_NAPI flag.
+    #[cfg(target_os = "linux")]
+    pub fn napi(&mut self) -> &mut Self {
+        self.napi = true;
         self
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -32,6 +32,9 @@ pub struct PlatformConfig {
 
     /// Enable IFF_NAPI
     pub(crate) napi: bool,
+
+    /// Enable IFF_VNET_HDR
+    pub(crate) vnet_hdr: bool,
 }
 
 /// `packet_information` is default to be `false` and `ensure_root_privileges` is default to be `true`.
@@ -41,6 +44,7 @@ impl Default for PlatformConfig {
             packet_information: false,
             ensure_root_privileges: true,
             napi: false,
+            vnet_hdr: false,
         }
     }
 }
@@ -70,6 +74,13 @@ impl PlatformConfig {
     #[cfg(target_os = "linux")]
     pub fn napi(&mut self) -> &mut Self {
         self.napi = true;
+        self
+    }
+
+    /// Enable IFF_VNET_HDR flag.
+    #[cfg(target_os = "linux")]
+    pub fn vnet_hdr(&mut self) -> &mut Self {
+        self.vnet_hdr = true;
         self
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -71,14 +71,12 @@ impl PlatformConfig {
     }
 
     /// Enable IFF_NAPI flag.
-    #[cfg(target_os = "linux")]
     pub fn napi(&mut self) -> &mut Self {
         self.napi = true;
         self
     }
 
     /// Enable IFF_VNET_HDR flag.
-    #[cfg(target_os = "linux")]
     pub fn vnet_hdr(&mut self) -> &mut Self {
         self.vnet_hdr = true;
         self


### PR DESCRIPTION
IFF_NAPI is useful since it can improve performance.

My reason for using VNET_HDR evaporated, but it did work so I thought I would include it, but it's pretty partial -- to be properly useful bindings are also needed for (a least) the `TUNSETOFFLOAD` and `TUN[SG]ETVNETHDRSZ` ioctls and the header struct itself. I'm happy to drop that commit if the usecase seems like something you don't want to take.